### PR TITLE
T23709 non-ISO images test fixes

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -36,7 +36,7 @@ autotest::loadtest "tests/_boot.pm";
 # ---
 
 if (!get_var("START_AFTER_TEST") && !get_var("BOOTFROM")) {
-    if (!get_var('LIVE')) {
+    if (!get_var('LIVE') && get_var('EOS_IMAGE_TYPE') ne 'full') {
         autotest::loadtest "tests/_fbe_install.pm";
     }
 


### PR DESCRIPTION
https://phabricator.endlessm.com/T23709

This is based on #6 (which is in turn based on #5), so actually only the most recent commit (“tests: Skip _fbe_install when running a non-ISO image”) needs to be reviewed. It’s a separate branch because it might potentially require some further work if tonight’s test run finds some failures with it.