### PR TITLE
templates: Switch to providing raw disk image as HDD_2 rather than HDD_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ been included too, for convenience.
 | `EOS_IMAGE_TYPE` | `boot`, `full`, `iso` | Undefined | Type of image this test is (or is to be) installed from; the type of image the SUT is booted from. From the `images` dictionary in the `manifest.json` file. Specific to eos-openqa-tests. |
 | `EOS_PLATFORM` | String | Undefined | `EIB_PLATFORM` from eos-image-builder. Specific to eos-openqa-tests. |
 | `FLAVOR` | String | Undefined | `${EIB_PERSONALITY}_{boot,full,iso}{,_update}`,  from eos-image-builder. Understood by OpenQA. |
-| `HDD_1_DECOMPRESS_URL` | URI | Undefined | URI of a `.img.xz` or `.img.gz` file to download and boot the system under test from. Understood by OpenQA. |
+| `HDD_2_DECOMPRESS_URL` | URI | Undefined | URI of a `.img.xz` or `.img.gz` file to download and boot the system under test from. Understood by OpenQA. |
 | `ISO_URL` | URI | Undefined | URI of a `.iso` file to download and boot the system under test from. Understood by OpenQA. |
 | `LIVE` | Boolean | False | The test is running on a live system rather than being installed. Specific to eos-openqa-tests. |
 | `OS_UPDATE_TO` | OS version number string | Undefined | EOS should be updated after installation, and the tests should expect that the update results in running the given OS version (as checked against `/etc/os-release`). If this variable is not set, the OS will not be updated. Specific to eos-openqa-tests. |

--- a/main.pm
+++ b/main.pm
@@ -12,7 +12,7 @@ testapi::set_distribution(endlessdistribution->new());
 #  - Boot
 #  - Install/First boot
 #  - Postinstall
-#  -
+#
 # These phases are very suspiciously similar to what Fedora does
 # (https://pagure.io/fedora-qa/os-autoinst-distri-fedora/).
 # The preinstall and install phases can be skipped by tests which set HDD_1 to
@@ -21,6 +21,10 @@ testapi::set_distribution(endlessdistribution->new());
 #  - START_AFTER_TEST = install_default_upload
 #  - BOOTFROM = c
 #  - HDD_1 = disk_%FLAVOR%_%MACHINE%.qcow2
+# The initial installation test (install_default_upload) uses an installation
+# disk or raw image set as HDD_2. It is (so far) the only test with two disks
+# configured.
+#
 # For details of START_AFTER_TEST, see
 # https://github.com/os-autoinst/openQA/blob/master/docs/WritingTests.asciidoc#user-content-job-dependencies.
 # For details of BOOTFROM and HDD_1, see

--- a/templates
+++ b/templates
@@ -471,6 +471,8 @@
       name => "live_default",
       settings => [
         { key => "LIVE", value => "1" },
+        # The ISO is provided as HDD_2 by eos-image-builder
+        { key => "NUMDISKS", value => "2" },
       ],
     },
     {
@@ -479,6 +481,8 @@
         { key => "STORE_HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
         # Minimum HDD size we support on real machines.
         { key => "HDDSIZEGB", value => "32" },
+        # The raw disk image or ISO is provided as HDD_2 by eos-image-builder
+        { key => "NUMDISKS", value => "2" },
       ],
     },
     {


### PR DESCRIPTION
The key values provided by the OpenQA request from the image builder
(which initially sets HDD_1_DECOMPRESS_URL) override the key values set
by the templates file, which means that every test gets
HDD_1_DECOMPRESS_URL set to the .img.xz file — including all the tests
which are supposed to run using the qcow2 generated by
install_default_upload. This means they don’t boot from the qcow2.

This wasn’t an issue for ISOs, since the image builder set ISO_URL for
them, rather than HDD_1_DECOMPRESS_URL; which resulted in ISO being
spuriously set alongside HDD_1. HDD_1 was preferred to boot from.

Fix this by providing the raw disk image as HDD_2 and only allowing a
couple of tests (install_default_upload and live_default) to have two
disks (and hence ‘see’ HDD_2). The qcow2 will continue to be set as
HDD_1.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T23709