### PR TITLE
templates: Switch back to providing raw disk image as HDD_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ been included too, for convenience.
 | `EOS_IMAGE_TYPE` | `boot`, `full`, `iso` | Undefined | Type of image this test is (or is to be) installed from; the type of image the SUT is booted from. From the `images` dictionary in the `manifest.json` file. Specific to eos-openqa-tests. |
 | `EOS_PLATFORM` | String | Undefined | `EIB_PLATFORM` from eos-image-builder. Specific to eos-openqa-tests. |
 | `FLAVOR` | String | Undefined | `${EIB_PERSONALITY}_{boot,full,iso}{,_update}`,  from eos-image-builder. Understood by OpenQA. |
-| `HDD_2_DECOMPRESS_URL` | URI | Undefined | URI of a `.img.xz` or `.img.gz` file to download and boot the system under test from. Understood by OpenQA. |
+| `HDD_1_DECOMPRESS_URL` | URI | Undefined | URI of a `.img.xz` or `.img.gz` file to download and boot the system under test from. Understood by OpenQA. |
 | `ISO_URL` | URI | Undefined | URI of a `.iso` file to download and boot the system under test from. Understood by OpenQA. |
 | `LIVE` | Boolean | False | The test is running on a live system rather than being installed. Specific to eos-openqa-tests. |
 | `OS_UPDATE_TO` | OS version number string | Undefined | EOS should be updated after installation, and the tests should expect that the update results in running the given OS version (as checked against `/etc/os-release`). If this variable is not set, the OS will not be updated. Specific to eos-openqa-tests. |

--- a/main.pm
+++ b/main.pm
@@ -22,8 +22,13 @@ testapi::set_distribution(endlessdistribution->new());
 #  - BOOTFROM = c
 #  - HDD_1 = disk_%FLAVOR%_%MACHINE%.qcow2
 # The initial installation test (install_default_upload) uses an installation
-# disk or raw image set as HDD_2. It is (so far) the only test with two disks
-# configured.
+# disk set as ISO or a raw image set as HDD_1. When booting from a raw image in
+# HDD_1, some initial installation will be done, then a qcow2 image will be
+# saved containing the installed disk state. This will be used by all dependent
+# tests, to skip running the installation again. The use of the qcow2 image is
+# forced in the `templates` file by setting `+HDD_1` rather than `HDD_1`.
+# Setting the latter in `templates` would mean its value is overridden by the
+# `HDD_1` value provided by eos-image-builder.
 #
 # For details of START_AFTER_TEST, see
 # https://github.com/os-autoinst/openQA/blob/master/docs/WritingTests.asciidoc#user-content-job-dependencies.

--- a/templates
+++ b/templates
@@ -471,8 +471,6 @@
       name => "live_default",
       settings => [
         { key => "LIVE", value => "1" },
-        # The ISO is provided as HDD_2 by eos-image-builder
-        { key => "NUMDISKS", value => "2" },
       ],
     },
     {
@@ -481,8 +479,6 @@
         { key => "STORE_HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
         # Minimum HDD size we support on real machines.
         { key => "HDDSIZEGB", value => "32" },
-        # The raw disk image or ISO is provided as HDD_2 by eos-image-builder
-        { key => "NUMDISKS", value => "2" },
       ],
     },
     {
@@ -491,7 +487,7 @@
         { key => "POSTINSTALL", value => "control_center_about" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -500,7 +496,7 @@
         { key => "POSTINSTALL", value => "desktop_chrome" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -509,7 +505,7 @@
         { key => "POSTINSTALL", value => "desktop_chromium" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -518,7 +514,7 @@
         { key => "POSTINSTALL", value => "desktop_encyclopedia" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -527,7 +523,7 @@
         { key => "POSTINSTALL", value => "desktop_libreoffice_writer" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -536,7 +532,7 @@
         { key => "POSTINSTALL", value => "desktop_search" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -545,7 +541,7 @@
         { key => "POSTINSTALL", value => "desktop_terminal" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -554,7 +550,7 @@
         { key => "POSTINSTALL", value => "discovery_feed" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -563,7 +559,7 @@
         { key => "POSTINSTALL", value => "install_flatpak" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
   ],


### PR DESCRIPTION
This is a partial revert of 2142bf0ec39c5648b41c0ba58dc39dd974e22a9a.

Instead of preventing the HDD_1 value from eos-image-builder overriding
the value from the templates file by using HDD_1 and HDD_2 (which has
problems documented in https://phabricator.endlessm.com/T23709#630172),
it seems we can prefix the HDD_1 values in the templates file with a ‘+’
to get them to take priority. Let’s try that.

Signed-off-by: Philip Withnall <withnall@endlessm.com>
https://phabricator.endlessm.com/T23709