### PR TITLE
T23844 Add OpenQA command line tool

### DIFF
--- a/eos-openqa-client/README.md
+++ b/eos-openqa-client/README.md
@@ -1,0 +1,7 @@
+The following two files need to be manually synced from eos-image-builder, as
+we can’t do a narrow clone with a submodule to only get the lib/ subdirectory
+from eos-image-builder. Also, eos-image-builder is private but eos-openqa-tests
+is public.
+
+ * eibimageserver.py
+ * eibopenqaserver.py

--- a/eos-openqa-client/eibimageserver.py
+++ b/eos-openqa-client/eibimageserver.py
@@ -1,0 +1,131 @@
+# -*- mode: Python; coding: utf-8 -*-
+
+# Endless image builder library — image server utilities
+#
+# Copyright © 2018  Endless Mobile, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import codecs
+import json
+import logging
+from urllib.parse import urlencode, urljoin
+from urllib.request import urlopen
+
+logger = logging.getLogger(__name__)
+
+
+def query_images(config, product=None, branch=None, arch=None, platform=None,
+                 personality=None, version=None, release=None,
+                 min_version=None, max_version=None):
+    """
+    Query the image server for images matching the given parameters.
+    If a parameter is not specified, no filtering is done by that parameter.
+    If `release` is specified, it must be boolean: specifying `None` for it
+    means no filtering is done by release status.
+    If `config` is not provided, the current config from eib is used.
+    """
+
+    # Construct image server API URL
+    params = {}
+
+    if product:
+        params['product'] = product
+    if branch:
+        params['branch'] = branch
+    if arch:
+        params['arch'] = arch
+    if platform:
+        params['platform'] = platform
+    if personality:
+        params['personality'] = personality
+    if release is not None:
+        params['release'] = 'true' if release else 'false'
+    if version:
+        params['version'] = version
+    if min_version:
+        params['min_version'] = min_version
+    if max_version:
+        params['max_version'] = max_version
+
+    url_root = config['image']['upload_api_url_root']
+    url = urljoin(url_root, '/api/image?' + urlencode(params))
+
+    def fetch_info(url, reader):
+        with urlopen(url) as f:
+            return json.load(reader(f))
+
+    logger.info('Fetching image info from %s', url)
+    reader = codecs.getreader('utf-8')
+    info = retry(fetch_info, url, reader)
+
+    if not isinstance(info, list):
+        raise Exception('JSON returned from images is not list')
+
+    if len(info) == 0:
+        # No previous builds for this variant, so trigger a new build
+        logger.info('No previous builds found for configuration')
+        return []
+
+    return info
+
+
+def retry(func, *args, max_retries=3, timeout=1, **kwargs):
+    """Retry a function in case of intermittent errors"""
+    retry = 0
+    while True:
+        try:
+            return func(*args, **kwargs)
+        except:
+            retry += 1
+            if retry > max_retries:
+                logger.error('Failed %d retries; giving up', max_retries)
+                raise
+
+            # Show the traceback so the error isn't hidden
+            logger.warning('Retrying attempt %d', retry, exc_info=True)
+            time.sleep(timeout)
+
+
+def download_image_file(image_info, personality, file_suffix):
+    """
+    Get a network object for a file in the given `image_info`.
+    The first file with suffix `.file_suffix` from the given `personality` will
+    be returned. If no such file is found, an Exception will be raised.
+    """
+    # Find the URI to the file with the given suffix
+    latest_url_root = image_info['url']
+    latest_suffixed_url = None
+    for filename in image_info['personality_files'][personality]:
+        if filename.endswith('.' + file_suffix):
+            latest_suffixed_url = urljoin(latest_url_root + '/', filename)
+
+    if not latest_suffixed_url:
+        raise Exception('No %s in latest build results' % file_suffix)
+
+    # Return a handle to the file
+    logger.info('Downloading latest %s from %s', file_suffix,
+                latest_suffixed_url)
+    return urlopen(latest_suffixed_url)
+
+
+def download_image_config(image_info, personality):
+    """download_image_file() with suffix set to `config.ini`."""
+    return download_image_file(image_info, personality, 'config.ini')
+
+
+def download_image_manifest(image_info, personality):
+    """download_image_file() with suffix set to `manifest.json`."""
+    return download_image_file(image_info, personality, 'manifest.json')

--- a/eos-openqa-client/eibopenqaserver.py
+++ b/eos-openqa-client/eibopenqaserver.py
@@ -1,0 +1,156 @@
+# -*- mode: Python; coding: utf-8 -*-
+
+# Endless image builder library — OpenQA server utilities
+#
+# Copyright © 2018  Endless Mobile, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import eibimageserver
+import hashlib
+import hmac
+import logging
+import os
+import requests
+import time
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def remap_arch(eib_arch):
+    """OpenQA has specific ideas about what architectures should be"""
+    mappings = {
+        'amd64': 'x86_64',
+        'armhf': 'arm',
+    }
+    return mappings[eib_arch] if eib_arch in mappings else eib_arch
+
+
+def send_request_for_manifest(manifest, image, upload_api_host,
+                              openqa_endpoint_url, api_key, api_secret,
+                              os_update_to=None):
+    image_details = manifest['images'][image]
+
+    download_url = \
+        'nightly/{product}-{arch}-{platform}/{branch}/{personality}/{build_version}'.format(**manifest)
+    image_url = 'http://{}/{}/{}'.format(upload_api_host, download_url,
+                                         image_details['file'])
+
+    # Work out which apps are installed on the image.
+    image_flatpak_remotes = manifest['flatpak']['remotes'].keys()
+    image_flatpak_runtimes = manifest['flatpak']['runtimes'].keys()
+    image_flatpak_apps = manifest['flatpak']['apps'].keys()
+
+    # Get the OSTree collection ID.
+    image_ostree_collection_id = manifest['ostree'].get('collection-id', '')
+
+    # Construct the flavor. This needs to include everything else that we want
+    # to differentiate on (aside from the branch, build_version, arch, product
+    # and platform, which are keyed separately). In particular, the
+    # personality, image type, and update path. We can’t include the actual
+    # update version in the FLAVOR, since that would mean the `templates` file
+    # in eos-openqa-tests.git would need updating for each release.
+    flavor = '{}_{}{}'.format(manifest['personality'], image,
+                              '_update' if os_update_to else '')
+
+    # Build an API request to send to OpenQA to add the new disk image to its
+    # list of images, and hence instantiate tests from the job templates for
+    # it. See the API documentation at http://openqa.dev.endlessm.com/api_help.
+    #
+    # We might expect to be called with variable values like the following:
+    #     EIB_IMAGE_LANGUAGE= EIB_PLATFORM=amd64 EIB_ARCH=amd64
+    #     EIB_PERSONALITY=base EIB_BUILD_VERSION=180807-224735 EIB_PRODUCT=eos
+    #     EIB_BRANCH=master
+    #     EIB_IMAGE_URL=http://images-dl.endlessm.com/nightly/eos-amd64-amd64/
+    #         master/base/180807-224735/
+    #     EIB_OUTVERSION=eos-master-amd64-amd64.180807-224735.base
+    #
+    # The resulting request will be essentially equivalent to running:
+    #     openqa-client --host openqa.dev.endlessm.com isos post \
+    #         ISO_URL=blah DISTRI=blas FLAVOR=blarf …
+    #
+    # Note that the request parameters have to be encoded in the URI, rather than
+    # the payload, so they are part of the request hash (X-API-Hash) and hence
+    # cannot be replayed elsewhere.
+    data = {
+        # OpenQA keys
+        'VERSION': manifest['branch'],
+        'BUILD': manifest['build_version'],
+        'DISTRI': manifest['product'],
+        'FLAVOR': flavor,
+        'ARCH': remap_arch(manifest['arch']),
+        # Custom keys, just to add a bit more metadata
+        'EOS_PLATFORM': manifest['platform'],
+        'EOS_IMAGE_FLATPAK_REMOTES': ' '.join(image_flatpak_remotes),
+        'EOS_IMAGE_FLATPAK_RUNTIMES': ' '.join(image_flatpak_runtimes),
+        'EOS_IMAGE_FLATPAK_APPS': ' '.join(image_flatpak_apps),
+        'EOS_IMAGE_OSTREE_COLLECTION_ID': image_ostree_collection_id,
+        'EOS_IMAGE_OSTREE_COMMIT': manifest['ostree']['commit'],
+        'EOS_IMAGE_OSTREE_DATE': manifest['ostree']['date'],
+        'EOS_IMAGE_OSTREE_REF': manifest['ostree']['ref'],
+        'EOS_IMAGE_OSTREE_REMOTE': manifest['ostree']['remote'],
+        'EOS_IMAGE_TYPE': image,
+    }
+    if 'image_language' in manifest:
+        data['EOS_IMAGE_LANGUAGE'] = manifest['image_language']
+    if os_update_to:
+        data['OS_UPDATE_TO'] = os_update_to
+
+    # Add the image URI.
+    if image == 'iso':
+        data['ISO_URL'] = image_url
+    elif image == 'full':
+        data['HDD_1_DECOMPRESS_URL'] = image_url
+    else:
+        raise ValueError('Unknown image ‘%s’' % image)
+
+    request = requests.Request('POST', openqa_endpoint_url)
+    request.params = data
+    request.data = ''
+    request = request.prepare()
+
+    # Request hashing copied from openQA-python-client:
+    # https://github.com/os-autoinst/openQA-python-client/blob/master/openqa_client/client.py
+    # (it seemed pointless to pull in a full dependency on it for just this).
+    timestamp = time.time()
+    path = request.path_url.replace('%20', '+').replace('~', '%7E')
+    api_hash = hmac.new(api_secret.encode(),
+                        '{0}{1}'.format(path, timestamp).encode(), hashlib.sha1)
+
+    headers = {
+        'Accept': 'application/json',
+        'X-API-Microtime': str(timestamp).encode(),
+        'X-API-Key': api_key,
+        'X-API-Hash': api_hash.hexdigest(),
+    }
+    request.headers.update(headers)
+    logger.debug('Sending OpenQA request to %s', request.url)
+
+    # If doing a dry run, bail before sending the request
+    if os.environ.get('EIB_DRY_RUN', None) == 'true':
+        logger.info('Dry run: would have POSTed request to %s', request.url)
+        return
+
+    # Send the request
+    with requests.Session() as session:
+        response = session.send(request)
+
+    logger.debug('OpenQA response status: %d', response.status_code)
+    logger.debug('OpenQA response headers: %s', response.headers)
+    logger.debug('OpenQA response content: %s', response.content)
+
+    # Raise an error if the server complained
+    response.raise_for_status()

--- a/eos-openqa-client/eos-openqa-client
+++ b/eos-openqa-client/eos-openqa-client
@@ -17,17 +17,25 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
 import argparse
+import configparser
 import eibimageserver
 import eibopenqaserver
 import json
 import logging
+import os
+import sys
 from urllib.request import urlopen
 
 
 # Image server which the manifest files live on.
 IMAGE_SERVER_HOST = 'images.endlessm.com'
+# OpenQA server hostname.
+OPENQA_SERVER_HOST = 'openqa.dev.endlessm.com'
 # OpenQA server REST API.
-OPENQA_SERVER_ENDPOINT_URI = 'https://openqa.dev.endlessm.com/api/v1/isos'
+OPENQA_SERVER_ENDPOINT_URI = \
+    'https://{}/api/v1/isos'.format(OPENQA_SERVER_HOST)
+# URI providing help on client.conf.
+OPENQA_CLIENT_HELP_URI = 'http://open.qa/docs/#_using_the_client_script'
 
 
 logger = logging.getLogger(__name__)
@@ -78,14 +86,63 @@ def load_manifest_for_path(path):
 
 
 def main():
+    # Try and load the config. It’s typically at ~/.config/openqa/client.conf,
+    # and contains key= and secret= keys in sections indexed by hostname. For
+    # example:
+    #
+    #    [openqa.dev.endlessm.com]
+    #    key=DEADBEEF
+    #    secret=A150DEADBEEF
+    #
+    # See http://open.qa/docs/#_using_the_client_script.
+    api_key = None
+    api_secret = None
+
+    try:
+        xdg_config_home = os.environ['XDG_CONFIG_HOME']
+    except KeyError:
+        xdg_config_home = os.path.expanduser('~/.config')
+    client_conf_file = os.path.join(xdg_config_home, 'openqa', 'client.conf')
+
+    config = configparser.ConfigParser()
+    config.read(client_conf_file)
+    try:
+        api_key = config[OPENQA_SERVER_HOST]['key']
+        api_secret = config[OPENQA_SERVER_HOST]['secret']
+    except KeyError:
+        pass
+
     # Parse command line arguments.
     parser = argparse.ArgumentParser(
-        description='Schedule OpenQA test runs for a given image manifest.')
+        description='Schedule OpenQA test runs for a given image manifest. '
+                    'Provide it with the URI or path to an image manifest '
+                    'JSON file, and it will schedule tests for all the images '
+                    'in that manifest.\n'
+                    '\n'
+                    'API configuration should be put in {}. See {} for '
+                    'help.'.format(client_conf_file, OPENQA_CLIENT_HELP_URI))
     parser.add_argument('manifest', help='manifest file or URI')
-    parser.add_argument('--api-key', help='OpenQA API key')
-    parser.add_argument('--api-secret', help='OpenQA API secret')
+    parser.add_argument('--api-key', required=False, default='',
+                        help='OpenQA API key (default: load from '
+                             '{})'.format(client_conf_file))
+    parser.add_argument('--api-secret', required=False, default='',
+                        help='OpenQA API secret (default: load from '
+                             '{})'.format(client_conf_file))
 
     args = parser.parse_args()
+
+    # API key/secret provided on the command line override the config file.
+    if args.api_key:
+        api_key = args.api_key
+    if args.api_secret:
+        api_secret = args.api_secret
+
+    if not api_key or not api_secret:
+        print('An --api-key and --api-secret must be provided, or specified '
+              'in {}.\nSee {}.'.format(
+                  client_conf_file, OPENQA_CLIENT_HELP_URI),
+              file=sys.stderr)
+        raise SystemExit(1)
 
     # Download the manifest.
     if args.manifest in ['master', 'eos3.3', 'eos3.4']:
@@ -99,14 +156,12 @@ def main():
         eibopenqaserver.send_request_for_manifest(manifest, 'full',
                                                   IMAGE_SERVER_HOST,
                                                   OPENQA_SERVER_ENDPOINT_URI,
-                                                  args.api_key,
-                                                  args.api_secret)
+                                                  api_key, api_secret)
     if 'iso' in manifest['images']:
         eibopenqaserver.send_request_for_manifest(manifest, 'iso',
                                                   IMAGE_SERVER_HOST,
                                                   OPENQA_SERVER_ENDPOINT_URI,
-                                                  args.api_key,
-                                                  args.api_secret)
+                                                  api_key, api_secret)
 
 
 if __name__ == '__main__':

--- a/eos-openqa-client/eos-openqa-client
+++ b/eos-openqa-client/eos-openqa-client
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright © 2018 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+import argparse
+import eibimageserver
+import eibopenqaserver
+import json
+import logging
+from urllib.request import urlopen
+
+
+# Image server which the manifest files live on.
+IMAGE_SERVER_HOST = 'images.endlessm.com'
+# OpenQA server REST API.
+OPENQA_SERVER_ENDPOINT_URI = 'https://openqa.dev.endlessm.com/api/v1/isos'
+
+
+logger = logging.getLogger(__name__)
+
+
+def load_manifest_for_branch(branch):
+    """
+    Download manifest file from the image server for the latest release on the
+    given branch, using default values for all the other parameters.
+
+    Return it as a Python object.
+    If there are no matching releases on the given branch, return None.
+    """
+    fake_config = {
+        'image': {
+            'upload_api_url_root': 'http://' + IMAGE_SERVER_HOST,
+        },
+    }
+    image_infos = eibimageserver.query_images(product='eos',
+                                              branch=branch,
+                                              arch='amd64',
+                                              platform='amd64',
+                                              personality='base',
+                                              config=fake_config)
+
+    if not image_infos:
+        return None
+
+    latest_info = max(image_infos, key=lambda el: el['ostree_date'])
+
+    # Download and load the manifest.
+    with eibimageserver.download_image_manifest(latest_info, 'base') as src:
+        return json.load(src)
+
+
+def load_manifest_for_uri(uri):
+    """Download a manifest from a URI."""
+    logger.info('Downloading %s', uri)
+    with urlopen(uri) as src:
+        return json.load(src)
+
+
+def load_manifest_for_path(path):
+    """Download a manifest from a URI."""
+    logger.info('Opening local file %s', path)
+    with open(path) as src:
+        return json.load(src)
+
+
+def main():
+    # Parse command line arguments.
+    parser = argparse.ArgumentParser(
+        description='Schedule OpenQA test runs for a given image manifest.')
+    parser.add_argument('manifest', help='manifest file or URI')
+    parser.add_argument('--api-key', help='OpenQA API key')
+    parser.add_argument('--api-secret', help='OpenQA API secret')
+
+    args = parser.parse_args()
+
+    # Download the manifest.
+    if args.manifest in ['master', 'eos3.3', 'eos3.4']:
+        manifest = load_manifest_for_branch(args.manifest)
+    if args.manifest.startswith('http'):
+        manifest = load_manifest_for_uri(args.manifest)
+    else:
+        manifest = load_manifest_for_path(args.manifest)
+
+    if 'full' in manifest['images']:
+        eibopenqaserver.send_request_for_manifest(manifest, 'full',
+                                                  IMAGE_SERVER_HOST,
+                                                  OPENQA_SERVER_ENDPOINT_URI,
+                                                  args.api_key,
+                                                  args.api_secret)
+    if 'iso' in manifest['images']:
+        eibopenqaserver.send_request_for_manifest(manifest, 'iso',
+                                                  IMAGE_SERVER_HOST,
+                                                  OPENQA_SERVER_ENDPOINT_URI,
+                                                  args.api_key,
+                                                  args.api_secret)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is based on #10, so ignore the commits from that.

This introduces a simple command line tool for scheduling OpenQA tests given an image manifest. Unfortunately I had to copy two files from eos-image-builder — see the `README.md` for the rationale about that. Better suggestions welcome.

https://phabricator.endlessm.com/T23844