### PR TITLE
eos-openqa-client: Use images.endlessm-sf.com for images host

### DIFF
--- a/eos-openqa-client/eos-openqa-client
+++ b/eos-openqa-client/eos-openqa-client
@@ -28,7 +28,7 @@ from urllib.request import urlopen
 
 
 # Image server which the manifest files live on.
-IMAGE_SERVER_HOST = 'images.endlessm.com'
+IMAGE_SERVER_HOST = 'images.endlessm-sf.com'
 # OpenQA server hostname.
 OPENQA_SERVER_HOST = 'openqa.dev.endlessm.com'
 # OpenQA server REST API.


### PR DESCRIPTION
This is the new canonical hostname. The public images.endlessm.com name
will be dropped when there are no more external users. The server will
only be accessible from the internal network after that. This should be
fine for the OpenQA server as it's now connected to the internal network
and can resolve endlessm-sf.com internal domains.

https://phabricator.endlessm.com/T23750