### PR TITLE
tests: Make FBE timezone page optional

### DIFF
--- a/tests/_fbe.pm
+++ b/tests/_fbe.pm
@@ -26,7 +26,12 @@ sub run {
             send_key('ret');
         }
 
-        assert_and_click('fbe_timezone', 'left', 10);
+        # The timezone screen is only shown if the timezone could not be
+        # detected automatically.
+        if (check_screen('fbe_timezone', 10)) {
+            assert_and_click('fbe_timezone', 'left', 10);
+        }
+
         assert_and_click('fbe_accounts', 'left', 10);
 
         assert_screen('fbe_about_you', 10);


### PR DESCRIPTION
As per https://phabricator.endlessm.com/T23631, the timezone page is now
only shown if the timezone could not be detected automatically. The
OpenQA machines are generally reliably geolocatable, so make the FBE
timezone page optional.

Signed-off-by: Philip Withnall <withnall@endlessm.com>