### PR TITLE
templates: Fix HDD_1 priority for desktop app tests

### DIFF
--- a/templates
+++ b/templates
@@ -654,7 +654,7 @@
         { key => "POSTINSTALL", value => "desktop_history" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -663,7 +663,7 @@
         { key => "POSTINSTALL", value => "desktop_dinosaurs" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {
@@ -672,7 +672,7 @@
         { key => "POSTINSTALL", value => "desktop_travel" },
         { key => "START_AFTER_TEST", value => "install_default_upload" },
         { key => "BOOTFROM", value => "c" },
-        { key => "HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {


### PR DESCRIPTION
Looks like the desktop app tests (history, travel, DINOSAURS) didn’t
receive the fix from 79fe521f for the priority of choosing which HDD_1
value to use for the test (whether it should come from the templates
file, or from the openqa-client invocation). Fix that.

🦕

Signed-off-by: Philip Withnall <withnall@endlessm.com>