### PR TITLE
Switch to production server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Endless OS OpenQA tests
 ===
 
 This repository contains a set of tests for Endless OS which get run on our
-OpenQA instance (https://openqa.dev.endlessm.com/) for every OS image build
+OpenQA instance (https://openqa.endlessm.com/) for every OS image build
 produced by our image builder.
 
 Documentation

--- a/eos-openqa-client/eibopenqaserver.py
+++ b/eos-openqa-client/eibopenqaserver.py
@@ -68,7 +68,7 @@ def send_request_for_manifest(manifest, image, upload_api_host,
 
     # Build an API request to send to OpenQA to add the new disk image to its
     # list of images, and hence instantiate tests from the job templates for
-    # it. See the API documentation at http://openqa.dev.endlessm.com/api_help.
+    # it. See the API documentation at http://openqa.endlessm.com/api_help.
     #
     # We might expect to be called with variable values like the following:
     #     EIB_IMAGE_LANGUAGE= EIB_PLATFORM=amd64 EIB_ARCH=amd64
@@ -79,7 +79,7 @@ def send_request_for_manifest(manifest, image, upload_api_host,
     #     EIB_OUTVERSION=eos-master-amd64-amd64.180807-224735.base
     #
     # The resulting request will be essentially equivalent to running:
-    #     openqa-client --host openqa.dev.endlessm.com isos post \
+    #     openqa-client --host openqa.endlessm.com isos post \
     #         ISO_URL=blah DISTRI=blas FLAVOR=blarf …
     #
     # Note that the request parameters have to be encoded in the URI, rather than

--- a/eos-openqa-client/eos-openqa-client
+++ b/eos-openqa-client/eos-openqa-client
@@ -30,7 +30,7 @@ from urllib.request import urlopen
 # Image server which the manifest files live on.
 IMAGE_SERVER_HOST = 'images.endlessm-sf.com'
 # OpenQA server hostname.
-OPENQA_SERVER_HOST = 'openqa.dev.endlessm.com'
+OPENQA_SERVER_HOST = 'openqa.endlessm.com'
 # OpenQA server REST API.
 OPENQA_SERVER_ENDPOINT_URI = \
     'https://{}/api/v1/isos'.format(OPENQA_SERVER_HOST)
@@ -90,7 +90,7 @@ def main():
     # and contains key= and secret= keys in sections indexed by hostname. For
     # example:
     #
-    #    [openqa.dev.endlessm.com]
+    #    [openqa.endlessm.com]
     #    key=DEADBEEF
     #    secret=A150DEADBEEF
     #


### PR DESCRIPTION
The production OpenQA server is now up at openqa.endlessm.com. Tests
should now be run there rather than the dev server.

Don't merge this until the production server is totally ready to go.

https://phabricator.endlessm.com/T23536