### PR TITLE
eibopenqaserver: send request data as body

### DIFF
--- a/eos-openqa-client/eibopenqaserver.py
+++ b/eos-openqa-client/eibopenqaserver.py
@@ -137,8 +137,7 @@ def send_request_for_manifest(manifest, image, upload_api_host,
         raise ValueError('Unknown image ‘%s’' % image)
 
     request = requests.Request('POST', openqa_endpoint_url)
-    request.params = data
-    request.data = ''
+    request.data = data
     request = request.prepare()
 
     # Request hashing copied from openQA-python-client:


### PR DESCRIPTION
It is common for HTTP servers to reject requests whose URLs are longer
than some arbitrary number of bytes. In our case, the threshold seems to
be 4096 bytes, which happens to be the length of the url generated for
an eosnonfree eos3.5 id image build.

Move the payload to the POST request body, which does not have a (low)
limit.

https://phabricator.endlessm.com/T24918