### PR TITLE
needles: Ignore Plymouth boot animation

### DIFF
--- a/needles/plymouth.json
+++ b/needles/plymouth.json
@@ -7,9 +7,17 @@
     {
       "xpos": 0,
       "ypos": 0,
-      "width": 1023,
-      "height": 767,
+      "width": 1024,
+      "height": 768,
       "type": "match"
+    },
+    {
+      "": "Ignore the animated 'Endless' text so we don't miss a match if the animation finishes too fast",
+      "xpos": 0,
+      "ypos": 403,
+      "width": 1024,
+      "height": 82,
+      "type": "exclude"
     }
   ]
 }

--- a/tests/_boot.pm
+++ b/tests/_boot.pm
@@ -6,13 +6,15 @@ use utils;
 sub run {
     my $self = shift;
 
-    # wait for bootloader to appear
-    # with a timeout explicitly lower than the default because
-    # the bootloader screen will timeout itself
-    assert_screen('plymouth', 60);
-
-    # Press Esc to show the boot progress for debugging
-    send_key('esc');
+    # Wait for bootloader to appear, using a timeout explicitly lower than the
+    # default because the bootloader screen will time out itself.
+    # On really fast boots, the bootloader may never actually show Endless
+    # branding, and will just go straight to the login screen. If so, this test
+    # is trivially complete and we do not want to block for too long.
+    if (check_screen('plymouth', 30)) {
+        # Press Esc to show the boot progress for debugging
+        send_key('esc');
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
If the Plymouth boot animation is cut off before it finishes, due to the
boot process going faster than expected, we will never actually match
its final frame. Perversely, this would mean the tests would be stuck
expecting the system to boot, while the system would have actually
booted ages ago.

Fix that by ignoring the animation area on the screen, so we essentially
match the background colour and logo. Waiting for the animation to
complete is then the responsibility of the next test. This is typically
_fbe_install.pm, which waits a long time for the first screen of the FBE
to appear.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24969