### PR TITLE
tests: Enable polkit debugging for all tests

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -57,6 +57,10 @@ if (!get_var('START_AFTER_TEST') && !get_var('BOOTFROM') && !get_var('FBE_TEST')
     # Enable coredump collection; needed for _check_crashes.pm below.
     autotest::loadtest "tests/_enable_coredumps.pm";
 
+    # Add debugging output for polkit prompts, since the text shown in the UI
+    # is often unhelpful.
+    autotest::loadtest "tests/_enable_polkit_debugging.pm";
+
     # Disable notification popups because they get in the way of a lot of needles.
     # Similarly, disable the screensaver.
     autotest::loadtest "tests/_disable_desktop_notifications.pm";

--- a/tests/_enable_polkit_debugging.pm
+++ b/tests/_enable_polkit_debugging.pm
@@ -1,0 +1,23 @@
+# vi: set shiftwidth=4 tabstop=4 expandtab:
+use base 'installedtest';
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    # Install an additional polkit rule which prints debug information for
+    # every authorisation request. This should help debug any problems which are
+    # found in tests, especially unexpected authorisation dialogs (where do they
+    # come from?).
+    $self->root_console();
+    assert_script_run('echo "polkit.addRule(function(action, subject) { polkit.log(\"action=\" + action); polkit.log(\"subject=\" + subject); return polkit.Result.NOT_HANDLED; });" > /etc/polkit-1/rules.d/10-debugging.rules', 30);
+    $self->exit_root_console();
+}
+
+sub test_flags {
+    return { fatal => 1 };
+}
+
+1;


### PR DESCRIPTION
A vain attempt to try and work out where the ‘need permission to install
software’ authorisation dialogues are coming from in various tests.

Signed-off-by: Philip Withnall <withnall@endlessm.com>