### PR TITLE
needles: allow FBE keyboard layout options to vary

### DIFF
--- a/needles/fbe_keyboard.json
+++ b/needles/fbe_keyboard.json
@@ -14,6 +14,14 @@
       "type": "match"
     },
     {
+      "": "Layouts other than English (US) may change",
+      "xpos": 264,
+      "ypos": 383,
+      "width": 390,
+      "height": 174,
+      "type": "exclude"
+    },
+    {
       "": "'Next' button",
       "xpos": 814,
       "ypos": 65,


### PR DESCRIPTION
This excludes the names of all layouts apart from the top one, which
should be "English (US)" and should be selected.

We want to improve the alternatives we offer, but at present they change
based on unknown factors outside our control (namely updates to xkb-data
plus, presumably, some undefined ordering of layouts for a given
language). For the sake of allowing the rest of the openQA suite to run,
we ignore which alternatives are selected, and just require that English
(US) is the default layout.

If we do add some logic in the FBE to improve the alternatives offered
for each language, we can test that separately.

https://phabricator.endlessm.com/T25604