### PR TITLE
tests: Add check for failed systemd units

### DIFF
--- a/tests/_check_crashes.pm
+++ b/tests/_check_crashes.pm
@@ -14,6 +14,14 @@ sub run {
     # FIXME: Ramp this up to check emerg..err. Currently a lot of true (unfixed) positives there.
     assert_script_run('[[ ! $(journalctl --priority emerg..crit --quiet --no-pager) ]]');
 
+    # Check no systemd units failed to start up. This isn’t caught by the
+    # test above, as systemd only emits a warning on unit failure, rather than
+    # an error.
+    #
+    # Note: The logic is perverse here, as is-failed returns exit status 0 if
+    # any units failed, and exit status 1 if all units succeeded.
+    assert_script_run('! systemctl is-failed --quiet \'*\'');
+
     $self->exit_root_console();
 }
 


### PR DESCRIPTION
This is a more specific version of the journalctl error message test,
because systemd only emits a warning if a unit failed.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T23726