### PR TITLE
tests: Add extra-languages flatpak setting tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ been included too, for convenience.
 | `EOS_IMAGE_FLATPAK_APPS` | Space-separated list of flatpak refs | Empty | List of flatpak apps preinstalled on the image. Specific to eos-openqa-tests. |
 | `EOS_IMAGE_FLATPAK_REMOTES` | Space-separated list of flatpak remote names | Empty | List of flatpak remotes preconfigured on the image. Specific to eos-openqa-tests. |
 | `EOS_IMAGE_FLATPAK_RUNTIMES` | Space-separated list of flatpak refs | Empty | List of flatpak runtimes preinstalled on the image. Specific to eos-openqa-tests. |
+| `EOS_IMAGE_FLATPAK_LOCALES` | Space-separated list of flatpak locales | Empty | List of locales downloaded when pulling flatpak refs on the image. Specific to eos-openqa-tests. |
 | `EOS_IMAGE_LANGUAGE` | `LANG` variable value | Undefined | Language the image is configured to use by default. Specific to eos-openqa-tests. |
 | `EOS_IMAGE_OSTREE_COLLECTION_ID` | OSTree collection ID | Undefined | Collection ID of the collection–ref used for the OS. Specific to eos-openqa-tests. |
 | `EOS_IMAGE_OSTREE_COMMIT` | OSTree commit checksum | Undefined | Commit checksum of the deployed OS. Specific to eos-openqa-tests. |
@@ -114,3 +115,4 @@ installed 3.`$x`, then stepwise update 3.`$x` → 3.`$x+1` → 3.`$x+2` → 3.`$
 → …. We will always end up testing the largest update step possible. In order to
 test stepwise updates we’d need to keep intermediate qcow2 images around from
 historic test runs. We do not currently do that.
+

--- a/eos-openqa-client/eibopenqaserver.py
+++ b/eos-openqa-client/eibopenqaserver.py
@@ -54,6 +54,9 @@ def send_request_for_manifest(manifest, image, upload_api_host,
     image_flatpak_runtimes = manifest['flatpak']['runtimes'].keys()
     image_flatpak_apps = manifest['flatpak']['apps'].keys()
 
+    # Work out which locales were set on an image
+    image_flatpak_locales = manifest['flatpak_locales']
+
     # Get the OSTree collection ID.
     image_ostree_collection_id = manifest['ostree'].get('collection-id', '')
 
@@ -97,6 +100,7 @@ def send_request_for_manifest(manifest, image, upload_api_host,
         'EOS_IMAGE_FLATPAK_REMOTES': ' '.join(image_flatpak_remotes),
         'EOS_IMAGE_FLATPAK_RUNTIMES': ' '.join(image_flatpak_runtimes),
         'EOS_IMAGE_FLATPAK_APPS': ' '.join(image_flatpak_apps),
+        'EOS_IMAGE_FLATPAK_LOCALES': ' '.join(image_flatpak_locales),
         'EOS_IMAGE_OSTREE_COLLECTION_ID': image_ostree_collection_id,
         'EOS_IMAGE_OSTREE_COMMIT': manifest['ostree']['commit'],
         'EOS_IMAGE_OSTREE_DATE': manifest['ostree']['date'],

--- a/templates
+++ b/templates
@@ -71,6 +71,39 @@
         flavor  => "base_full",
         version => "*",
       },
+      test_suite => { name => "check_flatpak_extra_languages" },
+    },
+    {
+      machine    => { name => "64bit" },
+      prio       => 10,
+      product    => {
+        arch    => "x86_64",
+        distri  => "eos",
+        flavor  => "base_full_update",
+        version => "*",
+      },
+      test_suite => { name => "check_flatpak_extra_languages" },
+    },
+    {
+      machine    => { name => "64bit" },
+      prio       => 10,
+      product    => {
+        arch    => "x86_64",
+        distri  => "eos",
+        flavor  => "base_iso",
+        version => "*",
+      },
+      test_suite => { name => "check_flatpak_extra_languages" },
+    },
+    {
+      machine    => { name => "64bit" },
+      prio       => 10,
+      product    => {
+        arch    => "x86_64",
+        distri  => "eos",
+        flavor  => "base_full",
+        version => "*",
+      },
       test_suite => { name => "control_center_about" },
     },
     {
@@ -807,6 +840,15 @@
         # adding an existing disk image as a qemu drive).
         { key => "HDDSIZEGB", value => "32" },
         { key => "HDDSIZEGB_1", value => "%HDDSIZEGB%" },
+      ],
+    },
+    {
+      name => "check_flatpak_extra_languages",
+      settings => [
+        { key => "POSTINSTALL", value => "check_flatpak_extra_languages" },
+        { key => "START_AFTER_TEST", value => "install_default_upload" },
+        { key => "BOOTFROM", value => "c" },
+        { key => "+HDD_1", value => "disk_%FLAVOR%_%MACHINE%.qcow2" },
       ],
     },
     {

--- a/tests/check_flatpak_extra_languages.pm
+++ b/tests/check_flatpak_extra_languages.pm
@@ -1,0 +1,32 @@
+# vi: set shiftwidth=4 tabstop=4 expandtab:
+use base 'installedtest';
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    my $default_extra_languages = "ar;bn;en;es;fr;id;pt;th;vi;zh";
+    my $extra_languages = get_var('EOS_IMAGE_FLATPAK_LOCALES', '');
+    $extra_languages =~ s/\ /;/ig;
+
+    # Test extra-languages key is present
+    $self->user_console();
+    if ($extra_languages eq $default_extra_languages) {
+        assert_script_run('flatpak config --system --get extra-languages', 60, '*unset*');
+    } elsif (!$extra_languages) {
+        assert_script_run('flatpak config --system --get extra-languages', 60, $extra_languages);
+    }
+
+    $self->exit_user_console();
+}
+
+sub test_flags {
+    # 'fatal'          - abort whole test suite if this fails (and set overall state 'failed')
+    # 'ignore_failure' - if this module fails, it will not affect the overall result at all
+    # 'milestone'      - after this test succeeds, update 'lastgood'
+    # 'norollback'     - don't roll back to 'lastgood' snapshot if this fails
+    return { fatal => 1 };
+}
+
+1;


### PR DESCRIPTION
Add tests to assert which locales where downloaded when pulling
flatpak refs, and whether or not they where set on the extra-languages
key.

https://phabricator.endlessm.com/T28469