### PR TITLE
templates: Temporarily disable parental controls tests

### DIFF
--- a/templates
+++ b/templates
@@ -742,72 +742,76 @@
       },
       test_suite => { name => "install_flatpak" },
     },
-    {
-      machine    => { name => "64bit" },
-      prio       => 10,
-      product    => {
-        arch    => "x86_64",
-        distri  => "eos",
-        flavor  => "base_full",
-        version => "*",
-      },
-      test_suite => { name => "parental_controls_gnome_software_oars" },
-    },
-    {
-      machine    => { name => "64bit" },
-      prio       => 10,
-      product    => {
-        arch    => "x86_64",
-        distri  => "eos",
-        flavor  => "base_full_update",
-        version => "*",
-      },
-      test_suite => { name => "parental_controls_gnome_software_oars" },
-    },
-    {
-      machine    => { name => "64bit" },
-      prio       => 10,
-      product    => {
-        arch    => "x86_64",
-        distri  => "eos",
-        flavor  => "base_iso",
-        version => "*",
-      },
-      test_suite => { name => "parental_controls_gnome_software_oars" },
-    },
-    {
-      machine    => { name => "64bit" },
-      prio       => 10,
-      product    => {
-        arch    => "x86_64",
-        distri  => "eos",
-        flavor  => "base_full",
-        version => "*",
-      },
-      test_suite => { name => "parental_controls_setup" },
-    },
-    {
-      machine    => { name => "64bit" },
-      prio       => 10,
-      product    => {
-        arch    => "x86_64",
-        distri  => "eos",
-        flavor  => "base_full_update",
-        version => "*",
-      },
-      test_suite => { name => "parental_controls_setup" },
-    },
-    {
-      machine    => { name => "64bit" },
-      prio       => 10,
-      product    => {
-        arch    => "x86_64",
-        distri  => "eos",
-        flavor  => "base_iso",
-        version => "*",
-      },
-      test_suite => { name => "parental_controls_setup" },
-    },
+    # FIXME: Parental controls tests are currently disabled while the controls
+    # for them are moved to an external app. See:
+    #  - https://phabricator.endlessm.com/T28737
+    #  - https://phabricator.endlessm.com/T28736
+    #{
+    #  machine    => { name => "64bit" },
+    #  prio       => 10,
+    #  product    => {
+    #    arch    => "x86_64",
+    #    distri  => "eos",
+    #    flavor  => "base_full",
+    #    version => "*",
+    #  },
+    #  test_suite => { name => "parental_controls_gnome_software_oars" },
+    #},
+    #{
+    #  machine    => { name => "64bit" },
+    #  prio       => 10,
+    #  product    => {
+    #    arch    => "x86_64",
+    #    distri  => "eos",
+    #    flavor  => "base_full_update",
+    #    version => "*",
+    #  },
+    #  test_suite => { name => "parental_controls_gnome_software_oars" },
+    #},
+    #{
+    #  machine    => { name => "64bit" },
+    #  prio       => 10,
+    #  product    => {
+    #    arch    => "x86_64",
+    #    distri  => "eos",
+    #    flavor  => "base_iso",
+    #    version => "*",
+    #  },
+    #  test_suite => { name => "parental_controls_gnome_software_oars" },
+    #},
+    #{
+    #  machine    => { name => "64bit" },
+    #  prio       => 10,
+    #  product    => {
+    #    arch    => "x86_64",
+    #    distri  => "eos",
+    #    flavor  => "base_full",
+    #    version => "*",
+    #  },
+    #  test_suite => { name => "parental_controls_setup" },
+    #},
+    #{
+    #  machine    => { name => "64bit" },
+    #  prio       => 10,
+    #  product    => {
+    #    arch    => "x86_64",
+    #    distri  => "eos",
+    #    flavor  => "base_full_update",
+    #    version => "*",
+    #  },
+    #  test_suite => { name => "parental_controls_setup" },
+    #},
+    #{
+    #  machine    => { name => "64bit" },
+    #  prio       => 10,
+    #  product    => {
+    #    arch    => "x86_64",
+    #    distri  => "eos",
+    #    flavor  => "base_iso",
+    #    version => "*",
+    #  },
+    #  test_suite => { name => "parental_controls_setup" },
+    #},
   ],
 
 


### PR DESCRIPTION
While the UI for setting parental controls is moved out from the control
centre to an external app and redesigned, disable the OpenQA tests for
them.

They will be re-enabled and reworked (new needles and code) once the new
UI is suitably stable. See T28736 for that.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28737